### PR TITLE
feat: Higher timeout

### DIFF
--- a/src/SubmissionSnsEventHandler.ts
+++ b/src/SubmissionSnsEventHandler.ts
@@ -56,7 +56,7 @@ export class SubmissionSnsEventHandler extends Construct {
         FORMIO_API_KEY_ARN: secret.secretArn,
         FORMIO_BASE_URL: StringParameter.valueForStringParameter(this, Statics.ssmFormIoBaseUrl),
       },
-      timeout: Duration.seconds(30),
+      timeout: Duration.minutes(5),
     });
     bucket.grantWrite(submissionLambda);
     sourceBucket.grantRead(submissionLambda);

--- a/src/app/submission/submission.lambda.ts
+++ b/src/app/submission/submission.lambda.ts
@@ -5,7 +5,6 @@ const submissionHandler = new SubmissionHandler();
 
 export async function handler(event: SNSEvent) {
   try {
-    console.debug(event);
     const messages = event.Records.map((record) => record.Sns);
     for (let message of messages) {
       await submissionHandler.handleRequest(message);


### PR DESCRIPTION
Lambda may need to transfer large files, set timeout to 5 minutes to make sure file transfer finishes.
