### PR TITLE
feat: Create SNS topic for cross account posting

### DIFF
--- a/src/ApiStack.ts
+++ b/src/ApiStack.ts
@@ -1,33 +1,90 @@
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { AnyPrincipal, Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { ITopic, Topic } from 'aws-cdk-lib/aws-sns';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
+import { Configurable } from './Configuration';
 import { Statics } from './statics';
 import { SubmissionSnsEventHandler } from './SubmissionSnsEventHandler';
 
+interface ApiStackProps extends StackProps, Configurable {};
 /**
  * Contains all API-related resources.
  */
 export class ApiStack extends Stack {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props: ApiStackProps) {
+    super(scope, id, props);
+
+    const internalTopic = new SNSTopic(this, 'submissions', { publishingAccountIds: props.configuration.allowedAccountIdsToPublishToSNS });
+    new SubmissionSnsEventHandler(this, 'submissionhandler', {
+      topicArns: [internalTopic.topic.topicArn, StringParameter.valueForStringParameter(this, Statics.ssmSubmissionTopicArn)],
+    });
+  }
+}
+
+interface SNSTopicProps extends StackProps {
+  /**
+   * Should the topic be protected by the KMS key (default true)
+   */
+  keyProtected?: boolean;
+
+  /**
+   * Allow access for different AWS accounts to publish to this topic
+   */
+  publishingAccountIds?: string[];
+}
+class SNSTopic extends Construct {
+  topic: ITopic;
+  constructor(scope: Construct, id: string, props: SNSTopicProps) {
     super(scope, id);
 
-    // const api = new RestApi(this, 'gateway');
-    // api.root.addMethod('ANY', new MockIntegration({
-    //   integrationResponses: [
-    //     { statusCode: '200' },
-    //   ],
-    //   passthroughBehavior: PassthroughBehavior.NEVER,
-    //   requestTemplates: {
-    //     'application/json': '{ "statusCode": 200 }',
-    //   },
-    // }), {
-    //   methodResponses: [
-    //     { statusCode: '200' },
-    //   ],
-    // });
+    let masterKey = (props.keyProtected !== false) ? this.encryptionKey() : undefined;
 
-    new SubmissionSnsEventHandler(this, 'submissionhandler', {
-      topicArn: StringParameter.valueForStringParameter(this, Statics.ssmSubmissionTopicArn),
+    this.topic = new Topic(this, 'submissions', {
+      displayName: 'submissions',
+      masterKey,
     });
+
+    this.allowCrossAccountAccess(props.publishingAccountIds);
+  }
+
+  /**
+   * Returns the customer manager key for the project
+   *
+   * @returns the encryption key
+   */
+  private encryptionKey() {
+    let masterKey = undefined;
+    masterKey = Key.fromKeyArn(this, 'key', StringParameter.valueForStringParameter(this, Statics.ssmDataKeyArn));
+    return masterKey;
+  }
+
+  /**
+   * Allow cross account access to this topic
+   *
+   * This allows lambda's with the execution role 'storesubmissions-lambda-role'
+   * in the accounts in `allowedAccountIds` access to publish to this topic.
+   *
+   * @param allowedAccountIds array of account IDs
+   */
+  allowCrossAccountAccess(allowedAccountIds?: string[]): void {
+    if (!allowedAccountIds || allowedAccountIds.length == 0) { return; }
+    const crossAccountPrincipalArns = allowedAccountIds.map(
+      (accountId) => `arn:aws:iam::${accountId}:role/storesubmissions-lambda-role`,
+    );
+    this.topic.addToResourcePolicy(new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: [
+        'SNS:Publish',
+      ],
+      resources: [this.topic.topicArn],
+      principals: [new AnyPrincipal()],
+      conditions: {
+        ArnLike: {
+          'aws:PrincipalArn': crossAccountPrincipalArns,
+        },
+      },
+    }));
   }
 }

--- a/src/ApiStage.ts
+++ b/src/ApiStage.ts
@@ -2,7 +2,7 @@ import { PermissionsBoundaryAspect } from '@gemeentenijmegen/aws-constructs';
 import { Aspects, Stage, StageProps, Tags } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { ApiStack } from './ApiStack';
-import { Configurable, Configuration } from './Configuration';
+import { Configurable } from './Configuration';
 import { Statics } from './statics';
 import { StorageStack } from './StorageStack';
 
@@ -13,8 +13,6 @@ interface ApiStageProps extends StageProps, Configurable { }
  */
 export class ApiStage extends Stage {
 
-  readonly configuration: Configuration;
-
   constructor(scope: Construct, id: string, props: ApiStageProps) {
     super(scope, id, props);
 
@@ -22,11 +20,9 @@ export class ApiStage extends Stage {
     Tags.of(this).add('Project', Statics.projectName);
     Aspects.of(this).add(new PermissionsBoundaryAspect());
 
-    this.configuration = props.configuration;
-
     const storageStack = new StorageStack(this, 'storage');
 
-    const apiStack = new ApiStack(this, 'api');
+    const apiStack = new ApiStack(this, 'api', { configuration: props.configuration } );
     apiStack.addDependency(storageStack);
   }
 }

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -26,6 +26,13 @@ export interface Configuration {
    * includePipelineValidationChcks
    */
   readonly includePipelineValidationChecks: boolean;
+
+  /**
+   * Allow this project's SNS topic to be published to
+   * by other accounts. This allows access to lambda
+   * execution roles named 'storesubmissions-lambda-role'.
+   */
+  readonly allowedAccountIdsToPublishToSNS?: string[];
 }
 
 export function getConfiguration(branchName: string): Configuration {
@@ -45,6 +52,7 @@ const configurations: { [name: string] : Configuration } = {
     deployFromEnvironment: Statics.gnBuildEnvironment,
     deployToEnvironment: Statics.appDevEnvironment,
     includePipelineValidationChecks: false,
+    allowedAccountIdsToPublishToSNS: [Statics.acceptanceWebformulierenAccountId],
   },
   production: {
     branchName: 'main',

--- a/src/app/submission/test/samples/sns.sample-duplicate-files.json
+++ b/src/app/submission/test/samples/sns.sample-duplicate-files.json
@@ -1,0 +1,34 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:eu-west-1: 315037222840:eform-submissions:293455ad-bb4b-4667-971d-7eaba358510d",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "538c926d-27a7-567b-b314-cf7e54168743",
+        "TopicArn": "arn:aws:sns:eu-west-1:315037222840:eform-submissions",
+        "Message": "{\"formId\": \"68c11b91-d127-414f-89cc-c6ef7ab3e1bf\",\"formTypeId\": \"test\",\"appId\": \"TDL\",\"reference\": \"TDL17.957\",\"data\": {\"bsn\": \"900026236\",\"kvk\": \"\",\"achternaam\": \"\",\"betrouwbaarheidsniveau\": \"digid\",\"familienaam\": \"\",\"geboortedatum\": \"01-01-1956\",\"gemeente\": \"\",\"geslacht\": \"\",\"huisnummer\": \"\",\"initialen\": \"\",\"inlogmiddel\": \"digid\",\"kenmerk\": \"TDL-17.957\",\"naamIngelogdeGebruiker\": \"H. de Jong\",\"nationaliteit\": \"\",\"postcode\": \"\",\"straatnaam\": \"\",\"totaalbedrag\": \"\",\"tussenvoegsel\": \"\",\"vipZaakType\": \"\",\"volledigeNaam\": \"H. de Jong\",\"voornaam\": \"\",\"woonplaats\": \"Nijmegen\",\"adres_nijmegen\": {\"adres_nijmegen-postalcode\": \"6511 pp\",\"adres_nijmegen-housenr\": \"6\",\"adres_nijmegen-streetname\": \"Korte Nieuwstraat\",\"adres_nijmegen-city\": \"Nijmegen\"},\"select_nijmegen\": \"\",\"eMailadres\": \"\",\"selectBoxesNijmegen\": {\"test\": true,\"tweede\": false,\"derde\": false},\"test\": false,\"dataGrid\": [{\"textareaNijmegen\": \"\"}],\"fileNijmegen\": [{\"storage\": \"url\",\"name\": \"test-1m-14cfa303-e58a-42dc-bd47-1299a789a627.pdf\",\"url\": \"https://example.com/-test-1m-blaat.pdf\",\"size\": \"1048576\",\"type\": \"application/pdf\",\"reference\": \"360fa9d4e798e8902d19e9757eef63ad\",\"originalName\": \"test-1m-blaat.pdf\",\"location\": \"randomid/files/test-1m-blaat.pdf\",\"bucketName\": \"randombucket\"},{\"storage\": \"url\",\"name\": \"test-1m-1differentrandomid.pdf\",\"url\": \"https://example.com/-test-1m-blaat.pdf\",\"size\": \"1048576\",\"type\": \"application/pdf\",\"reference\": \"360fa9d4e798e8902d19e9757eef63ad\",\"originalName\": \"test-1m-blaat.pdf\",\"location\": \"randomdifferentid/files/test-1m-blaat.pdf\",\"bucketName\": \"randombucket\"},{\"storage\": \"url\",\"name\": \"test-1m-14cfa303-e58a-42dc-bd47-1299a789a627.pdf\",\"url\": \"https://example.com/-1299a789a627.pdf\",\"size\": \"1048576\",\"type\": \"application/pdf\",\"reference\": \"360fa9d4e798e8902d19e9757eef63ad\",\"originalName\": \"test-1m.pdf\",\"location\": \"randomid/files/test-1m.pdf\",\"bucketName\": \"randombucket\"}],\"opslaan\": false,\"volgende\": true,\"submit1\": false,\"submit\": true},\"metadata\": {\"timezone\": \"Europe/Amsterdam\",\"offset\": 120,\"origin\": \"https://app6-accp.nijmegen.nl\",\"referrer\": \"\",\"browserName\": \"Netscape\",\"userAgent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5.2 Safari/605.1.15\",\"pathName\": \"/\",\"onLine\": true},\"employeeData\": {},\"pdf\": {\"reference\": \"c07e4f3b36955bb31565fb1ef7bdefaf\",\"location\": \"randomid/pdf/TDL17.957\",\"bucketName\": \"randombucket\"},\"brpData\": {\"Persoon\": {\"BSN\": {\"BSN\": \"900026236\"},\"Persoonsgegevens\": {\"Voorletters\": \"H.\",\"Voornamen\": \"Hans\",\"Voorvoegsel\": \"de\",\"Geslachtsnaam\": \"Jong\",\"Achternaam\": \"de Jong\",\"Naam\": \"H. de Jong\",\"Geboortedatum\": \"01-01-1956\",\"Geslacht\": \"M\",\"NederlandseNationaliteit\": \"Ja\",\"Geboorteplaats\": \"Nijmegen\",\"Geboorteland\": \"Nederland\"},\"Adres\": {\"Straat\": \"Kelfkensbos\",\"Huisnummer\": \"80-A-1\",\"Gemeente\": \"Nijmegen\",\"Postcode\": \"6511 RN\",\"Woonplaats\": \"Nijmegen\"},\"Reisdocument\": {\"Documentsoort\": \"\",\"Documentnummer\": \"\",\"Uitgiftedatum\": \"\",\"Verloopdatum\": \"\"},\"ageLimits\": {\"over12\": \"Yes\",\"over16\": \"Yes\",\"over18\": \"Yes\",\"over21\": \"Yes\",\"over65\": \"Yes\"}}},\"bsn\": \"900026236\"}",
+        "Timestamp": "2023-06-26T11:07:29.154Z",
+        "SignatureVersion": "1",
+        "Signature": "MP6SMqgHFUA3eWuR/PkRLKW/eLzsbGa81a7NVN7/8Fq94K9X9DgaiqMmWq1CwWNpR5K8ISd5lwE+MIBK1h19lFVhYa/QgbIWsys8G9pCvfHdI1s+xzEAfVxgrRPa71QHkGNrrxqJN5c78ahChN9IG/XRPddYqltei5ZX6BRdFwTc0pGLkCy0hNj6kqJ30VGT8jpJoo/+PFt0PXTs+NCaOSfUo+kxO2VKtgXmHElPzfb7VAV2QFGtVkcGBgnxA5o0eEwepjf844L/BC3YsHxqHLVeg9rreMtkvoAsETRo9Qy8anYC1TcQ4rkmyWaKp4QlSllidzZxjKtbgvuC5ZPHRQ==",
+        "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-01d088a6f77103d0fe307c0069e40ed6.pem",
+        "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:315037222840:eform-submissions:bb9d78bf-834b-4146-898c-ff3456b26f9e",
+        "MessageAttributes": {
+          "BRP_data": {
+            "Type": "String",
+            "Value": "true"
+          },
+          "AppId": {
+            "Type": "String",
+            "Value": "APV"
+          },
+          "KVK_data": {
+            "Type": "String",
+            "Value": "false"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -21,6 +21,8 @@ export abstract class Statics {
     region: 'eu-central-1',
   };
 
+  static readonly acceptanceWebformulierenAccountId = '315037222840';
+
   static ssmDataKeyArn: string = `/${this.projectName}/dataKeyArn`;
   static ssmSubmissionBucketArn: string = `/${this.projectName}/submissionBucketArn`;
   static ssmSourceBucketArn: string = `/${this.projectName}/sourceBucketArn`;

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,24 +1,35 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import { ApiStack } from '../src/ApiStack';
 import { Configuration } from '../src/Configuration';
 import { PipelineStack } from '../src/PipelineStack';
 
+const configuration: Configuration = {
+  branchName: 'stacktest',
+  deployFromEnvironment: {
+    account: '12345678',
+    region: 'eu-central-1',
+  },
+  deployToEnvironment: {
+    account: '12345678',
+    region: 'eu-central-1',
+  },
+  includePipelineValidationChecks: false,
+};
+
 test('Snapshot', () => {
   const app = new App();
-  const configuration: Configuration = {
-    branchName: 'stacktest',
-    deployFromEnvironment: {
-      account: '12345678',
-      region: 'eu-central-1',
-    },
-    deployToEnvironment: {
-      account: '12345678',
-      region: 'eu-central-1',
-    },
-    includePipelineValidationChecks: false,
-  };
+
   const stack = new PipelineStack(app, 'test', { env: configuration.deployFromEnvironment, configuration });
 
   const template = Template.fromStack(stack);
   expect(template.toJSON()).toMatchSnapshot();
+});
+
+
+test('Api Stack', () => {
+  const app = new App();
+  const apiStack = new ApiStack(app, 'api', { configuration });
+  const template = Template.fromStack(apiStack);
+  expect(template.resourceCountIs('AWS::SNS::Subscription', 2));
 });


### PR DESCRIPTION
Adds an SNS topic, which can be subscribed to from a different account. It allows the accp webformulieren account to post to this topic. Submissions on this topic will be processed the same way other submissions are handled.

Required for https://github.com/GemeenteNijmegen/mijn-nijmegen/issues/740