### PR TITLE
feat: connect submission storage to new landingzone production env

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -75,11 +75,11 @@ const configurations: { [name: string] : Configuration } = {
     includePipelineValidationChecks: false,
     allowedAccountIdsToPublishToSNS: [
       Statics.productionWebformulierenAccountIdOldLz,
-      // Statics.productionWebformulierenAccountId, // TODO enable when live with new production environment!
+      Statics.productionWebformulierenAccountId,
     ],
     subscribeToTopicArns: [
       'arn:aws:sns:eu-west-1:196212984627:eform-submissions',
-      //'arn:aws:sns:eu-central-1:147064197580:eform-submissions', // TODO enable when live with new production environment!
+      'arn:aws:sns:eu-central-1:147064197580:eform-submissions',
     ],
   },
 };

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -33,6 +33,13 @@ export interface Configuration {
    * execution roles named 'storesubmissions-lambda-role'.
    */
   readonly allowedAccountIdsToPublishToSNS?: string[];
+
+  /**
+   * A list of SNS topic ARNs to subscribe to.
+   * Published submissions on this topic are then
+   * processed.
+   */
+  readonly subscribeToTopicArns?: string[];
 }
 
 export function getConfiguration(branchName: string): Configuration {
@@ -56,6 +63,10 @@ const configurations: { [name: string] : Configuration } = {
       Statics.acceptanceWebformulierenAccountIdOldLz,
       Statics.acceptanceWebformulierenAccountId,
     ],
+    subscribeToTopicArns: [
+      'arn:aws:sns:eu-west-1:315037222840:eform-submissions',
+      'arn:aws:sns:eu-central-1:338472043295:eform-submissions',
+    ],
   },
   production: {
     branchName: 'main',
@@ -65,6 +76,10 @@ const configurations: { [name: string] : Configuration } = {
     allowedAccountIdsToPublishToSNS: [
       Statics.productionWebformulierenAccountIdOldLz,
       // Statics.productionWebformulierenAccountId, // TODO enable when live with new production environment!
+    ],
+    subscribeToTopicArns: [
+      'arn:aws:sns:eu-west-1:196212984627:eform-submissions',
+      //'arn:aws:sns:eu-central-1:147064197580:eform-submissions', // TODO enable when live with new production environment!
     ],
   },
 };

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -52,13 +52,19 @@ const configurations: { [name: string] : Configuration } = {
     deployFromEnvironment: Statics.gnBuildEnvironment,
     deployToEnvironment: Statics.appDevEnvironment,
     includePipelineValidationChecks: false,
-    allowedAccountIdsToPublishToSNS: [Statics.acceptanceWebformulierenAccountId],
+    allowedAccountIdsToPublishToSNS: [
+      Statics.acceptanceWebformulierenAccountIdOldLz,
+      Statics.acceptanceWebformulierenAccountId,
+    ],
   },
   production: {
     branchName: 'main',
     deployFromEnvironment: Statics.gnBuildEnvironment,
     deployToEnvironment: Statics.appProdEnvironment,
     includePipelineValidationChecks: false,
-    allowedAccountIdsToPublishToSNS: [Statics.productionWebformulierenAccountId],
+    allowedAccountIdsToPublishToSNS: [
+      Statics.productionWebformulierenAccountIdOldLz,
+      // Statics.productionWebformulierenAccountId, // TODO enable when live with new production environment!
+    ],
   },
 };

--- a/src/StorageStack.ts
+++ b/src/StorageStack.ts
@@ -78,11 +78,6 @@ export class StorageStack extends Stack {
    * Add general parameters, the values of which should be added later
    */
   private addParameters() {
-    new StringParameter(this, 'submissionTopicArn', {
-      stringValue: '-',
-      parameterName: Statics.ssmSubmissionTopicArn,
-    });
-
     new StringParameter(this, 'sourceBucketArn', {
       stringValue: '-',
       parameterName: Statics.ssmSourceBucketArn,

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -35,7 +35,6 @@ export abstract class Statics {
   static ssmSubmissionBucketName: string = `/${this.projectName}/submissionBucketName`;
   static ssmSubmissionTableArn: string = `/${this.projectName}/submissionTableArn`;
   static ssmSubmissionTableName: string = `/${this.projectName}/submissionTableName`;
-  static ssmSubmissionTopicArn: string = `/${this.projectName}/ssmSubmissionTopicArn`;
   static ssmFormIoBaseUrl: string = `/${this.projectName}/formIoBaseUrl`;
 
   static secretFormIoApiKey: string = `/${this.projectName}/FormIoAPIKey`;

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -21,8 +21,12 @@ export abstract class Statics {
     region: 'eu-central-1',
   };
 
-  static readonly acceptanceWebformulierenAccountId = '315037222840';
-  static readonly productionWebformulierenAccountId = '196212984627';
+  static readonly acceptanceWebformulierenAccountIdOldLz = '315037222840';
+  static readonly productionWebformulierenAccountIdOldLz = '196212984627';
+
+  static readonly acceptanceWebformulierenAccountId = '338472043295';
+  static readonly productionWebformulierenAccountId = '147064197580';
+
 
   static ssmDataKeyArn: string = `/${this.projectName}/dataKeyArn`;
   static ssmSubmissionBucketArn: string = `/${this.projectName}/submissionBucketArn`;

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -31,5 +31,5 @@ test('Api Stack', () => {
   const app = new App();
   const apiStack = new ApiStack(app, 'api', { configuration });
   const template = Template.fromStack(apiStack);
-  expect(template.resourceCountIs('AWS::SNS::Subscription', 2));
+  expect(template.hasResource('AWS::SNS::Subscription', {}));
 });


### PR DESCRIPTION
- Subscribe to multiple SNS topics e.g. multiple webformulieren environments
- No conflicts will occur as the reference in the new production environment is bumped with a large gap (increased to 200.000 with a gap of 50.000 from the value in the old production environment that is increased from 10.000 to 150.000 over 2 years).