### PR TITLE
feat: remove configuration for old landingzone

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -60,11 +60,9 @@ const configurations: { [name: string] : Configuration } = {
     deployToEnvironment: Statics.appDevEnvironment,
     includePipelineValidationChecks: false,
     allowedAccountIdsToPublishToSNS: [
-      //Statics.acceptanceWebformulierenAccountIdOldLz,
       Statics.acceptanceWebformulierenAccountId,
     ],
     subscribeToTopicArns: [
-      //'arn:aws:sns:eu-west-1:315037222840:eform-submissions', //old lz
       'arn:aws:sns:eu-central-1:338472043295:eform-submissions',
     ],
   },
@@ -74,11 +72,9 @@ const configurations: { [name: string] : Configuration } = {
     deployToEnvironment: Statics.appProdEnvironment,
     includePipelineValidationChecks: false,
     allowedAccountIdsToPublishToSNS: [
-      //Statics.productionWebformulierenAccountIdOldLz,
       Statics.productionWebformulierenAccountId,
     ],
     subscribeToTopicArns: [
-      //'arn:aws:sns:eu-west-1:196212984627:eform-submissions', //old lz
       'arn:aws:sns:eu-central-1:147064197580:eform-submissions',
     ],
   },

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -60,11 +60,11 @@ const configurations: { [name: string] : Configuration } = {
     deployToEnvironment: Statics.appDevEnvironment,
     includePipelineValidationChecks: false,
     allowedAccountIdsToPublishToSNS: [
-      Statics.acceptanceWebformulierenAccountIdOldLz,
+      //Statics.acceptanceWebformulierenAccountIdOldLz,
       Statics.acceptanceWebformulierenAccountId,
     ],
     subscribeToTopicArns: [
-      'arn:aws:sns:eu-west-1:315037222840:eform-submissions',
+      //'arn:aws:sns:eu-west-1:315037222840:eform-submissions', //old lz
       'arn:aws:sns:eu-central-1:338472043295:eform-submissions',
     ],
   },
@@ -74,11 +74,11 @@ const configurations: { [name: string] : Configuration } = {
     deployToEnvironment: Statics.appProdEnvironment,
     includePipelineValidationChecks: false,
     allowedAccountIdsToPublishToSNS: [
-      Statics.productionWebformulierenAccountIdOldLz,
+      //Statics.productionWebformulierenAccountIdOldLz,
       Statics.productionWebformulierenAccountId,
     ],
     subscribeToTopicArns: [
-      'arn:aws:sns:eu-west-1:196212984627:eform-submissions',
+      //'arn:aws:sns:eu-west-1:196212984627:eform-submissions', //old lz
       'arn:aws:sns:eu-central-1:147064197580:eform-submissions',
     ],
   },

--- a/src/app/submission/Submission.ts
+++ b/src/app/submission/Submission.ts
@@ -93,7 +93,7 @@ export class Submission {
     const copyPromises: Promise<any>[] = [];
     copyPromises.push(this.storage.store(`${this.key}/submission.json`, JSON.stringify(this.rawSubmission))); // Submission
     copyPromises.push(this.storage.store(`${this.key}/formdefinition.json`, JSON.stringify(formDefinition))); // Form def
-    copyPromises.push(this.storage.copy(this.pdf.bucket, this.pdf.key, 'eu-west-1', pdfKey)); // PDF
+    copyPromises.push(this.storage.copy(this.pdf.bucket, this.pdf.key, 'eu-central-1', pdfKey)); // PDF
     copyPromises.push(...this.attachmentPromises());
     try {
       await Promise.all(copyPromises);
@@ -142,7 +142,7 @@ export class Submission {
     const promises = [];
     if (this.attachments) {
       for (let attachment of this.attachments) {
-        promises.push(this.storage.copy(attachment.bucket, attachment.key, 'eu-west-1', `${this.key}/attachments/${attachment.originalName}`));
+        promises.push(this.storage.copy(attachment.bucket, attachment.key, 'eu-central-1', `${this.key}/attachments/${attachment.originalName}`));
       }
     }
     return promises;

--- a/src/app/submission/test/storage.test.ts
+++ b/src/app/submission/test/storage.test.ts
@@ -8,6 +8,6 @@ describe('Storage methods', () => {
   });
 
   test('Copy method returns succesfully', async () => {
-    expect(await storage.copy('somebucket', 'somekey', 'eu-west-1', 'somekey')).toBeTruthy();
+    expect(await storage.copy('somebucket', 'somekey', 'eu-central-1', 'somekey')).toBeTruthy();
   });
 });


### PR DESCRIPTION
- Remove subscriptions to sns topics and policy to publish to sns
- Replaced hard coded eu-west-1 references (fixes: `PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.`)