### PR TITLE
fix: Timezone independent date from listSubmissions

### DIFF
--- a/src/app/listSubmissions/ListSubmissionsRequestHandler.ts
+++ b/src/app/listSubmissions/ListSubmissionsRequestHandler.ts
@@ -1,7 +1,7 @@
 import { ApiGatewayV2Response, Response } from '@gemeentenijmegen/apigateway-http/lib/V2/Response';
-import { EventParameters } from './parsedEvent';
 import { Database, DynamoDBDatabase } from '../submission/Database';
 import { S3Storage, Storage } from '../submission/Storage';
+import { EventParameters } from './parsedEvent';
 
 export class ListSubmissionsRequestHandler {
 
@@ -48,7 +48,7 @@ export class ListSubmissionsRequestHandler {
         return {
           ...result,
           formName: submissions[result.key].formTypeId,
-          date: new Date(...submissions[result.key].metadata.timestamp as []),
+          date: new Date(Date.UTC(...submissions[result.key].metadata.timestamp as [number, number, number, number, number, number, number])),
         };
       } else {
         return results;

--- a/src/app/listSubmissions/test/listSubmissionsRequestHandler.test.ts
+++ b/src/app/listSubmissions/test/listSubmissionsRequestHandler.test.ts
@@ -6,12 +6,12 @@ const listResults = [{
   pdf: 'TDL17.957/submission.pdf',
 }];
 
-// const expectedListResults = [{
-//   key: 'TDL17.957',
-//   pdf: 'TDL17.957/submission.pdf',
-//   formName: 'test',
-//   date: '2024-03-01T15:35:55.229Z',
-// }];
+const expectedListResults = [{
+  key: 'TDL17.957',
+  pdf: 'TDL17.957/submission.pdf',
+  formName: 'test',
+  date: '2024-03-01T16:35:55.229Z',
+}];
 
 const getObjectMock = (file:any) => ({
   Body: {
@@ -58,8 +58,8 @@ beforeAll(() => {
 
 describe('Request Handler', () => {
   test('Handler correctly returns', async() => {
-    await handler.handleRequest({ userId: '900222670', userType: 'person' });
-    // expect(result.body).toBe(JSON.stringify(expectedListResults)); // TODO fix this test
+    const result = await handler.handleRequest({ userId: '900222670', userType: 'person' });
+    expect(result.body).toBe(JSON.stringify(expectedListResults)); // TODO fix this test
     console.error('TODO this test should be fixed!');
   });
 


### PR DESCRIPTION
Submission object now creates date using `Date.UTC`, the timestamp provided in the submission is in UTC as well. This should also prevent differing behaviour in CI tests.