### PR TITLE
feat: Add more metadata to dynamoDB

### DIFF
--- a/src/app/submission/Database.ts
+++ b/src/app/submission/Database.ts
@@ -7,6 +7,9 @@ export interface SubmissionData {
   key: string;
   pdf: string;
   attachments?: s3Object[];
+  dateSubmitted?: string;
+  formName?: string;
+  formTitle?: string;
 }
 
 export interface ListSubmissionParameters {
@@ -64,6 +67,9 @@ export class DynamoDBDatabase implements Database {
           userId: parameters.userId,
           key: item?.sk.S ?? '',
           pdf: item?.pdfKey.S ?? '',
+          dateSubmitted: item?.dateSubmitted.S ?? '',
+          formName: item?.formName.S ?? '',
+          formTitle: item?.formTitle.S ?? '',
         };
       }) ?? [];
       return items;
@@ -80,6 +86,15 @@ export function dynamoDBItem(pk: string, sk: string, submission: SubmissionData)
     sk: { S: sk },
     pdfKey: { S: submission.pdf },
   };
+  if (submission.dateSubmitted) {
+    item.dateSubmitted = { S: item.dateSubmitted };
+  }
+  if (submission.formName) {
+    item.formName = { S: item.formName };
+  }
+  if (submission.formTitle) {
+    item.formTitle = { S: item.formTitle };
+  }
   if (submission.attachments) {
     item.attachments = {
       L: submission.attachments?.map((attachment) => {

--- a/src/app/submission/Database.ts
+++ b/src/app/submission/Database.ts
@@ -87,13 +87,13 @@ export function dynamoDBItem(pk: string, sk: string, submission: SubmissionData)
     pdfKey: { S: submission.pdf },
   };
   if (submission.dateSubmitted) {
-    item.dateSubmitted = { S: item.dateSubmitted };
+    item.dateSubmitted = { S: submission.dateSubmitted };
   }
   if (submission.formName) {
-    item.formName = { S: item.formName };
+    item.formName = { S: submission.formName };
   }
   if (submission.formTitle) {
-    item.formTitle = { S: item.formTitle };
+    item.formTitle = { S: submission.formTitle };
   }
   if (submission.attachments) {
     item.attachments = {

--- a/src/app/submission/FormConnector.ts
+++ b/src/app/submission/FormConnector.ts
@@ -6,7 +6,7 @@ export interface FormConnector {
 export class MockFormConnector implements FormConnector {
   async definition(formName: string) {
     return Promise.resolve({
-      formName: formName,
+      name: formName,
       title: formName,
     });
   }

--- a/src/app/submission/Submission.ts
+++ b/src/app/submission/Submission.ts
@@ -118,10 +118,6 @@ export class Submission {
 
     const timestamp = this.parsedSubmission.metadata.timestamp.slice(0, -1) as [number, number, number, number, number, number];
     timestamp.slice(0);
-    console.debug('timestamp', timestamp);
-    console.debug('form def', formDefinition);
-    console.debug(timestamp);
-    console.debug(new Date(Date.UTC(...timestamp)).toISOString());
     const parsedDefinition = FormDefinitionSchema.parse(formDefinition);
     // Store in dynamodb
     await this.database.storeSubmission({

--- a/src/app/submission/Submission.ts
+++ b/src/app/submission/Submission.ts
@@ -115,7 +115,7 @@ export class Submission {
     } catch (error: any) {
       console.error(error);
     }
-
+    // Timestamps are provided as an array of [year, monthindex, day, hour, minute, second, somethingwhichisnotmillis]. We don't need subsecond precision, so we slice that element off.
     const timestamp = this.parsedSubmission.metadata.timestamp.slice(0, -1) as [number, number, number, number, number, number];
     timestamp.slice(0);
     const parsedDefinition = FormDefinitionSchema.parse(formDefinition);

--- a/src/app/submission/Submission.ts
+++ b/src/app/submission/Submission.ts
@@ -116,12 +116,18 @@ export class Submission {
       console.error(error);
     }
 
+    const timestamp = this.parsedSubmission.metadata.timestamp as [number, number, number, number, number, number, number];
+    console.debug('form def', formDefinition);
+    const parsedDefinition = FormDefinitionSchema.parse(formDefinition);
     // Store in dynamodb
     await this.database.storeSubmission({
       userId: this.userId(),
       key: this.key,
       pdf: pdfKey,
       attachments: this.attachments,
+      dateSubmitted: new Date(Date.UTC(...timestamp)).toISOString(),
+      formName: this.parsedSubmission.formTypeId,
+      formTitle: parsedDefinition.title,
     });
 
     return true;
@@ -163,3 +169,8 @@ export class Submission {
     return promises;
   }
 }
+
+export const FormDefinitionSchema = z.object({
+  title: z.string(),
+  name: z.string(),
+});

--- a/src/app/submission/Submission.ts
+++ b/src/app/submission/Submission.ts
@@ -116,8 +116,12 @@ export class Submission {
       console.error(error);
     }
 
-    const timestamp = this.parsedSubmission.metadata.timestamp as [number, number, number, number, number, number, number];
+    const timestamp = this.parsedSubmission.metadata.timestamp.slice(0, -1) as [number, number, number, number, number, number];
+    timestamp.slice(0);
+    console.debug('timestamp', timestamp);
     console.debug('form def', formDefinition);
+    console.debug(timestamp);
+    console.debug(new Date(Date.UTC(...timestamp)).toISOString());
     const parsedDefinition = FormDefinitionSchema.parse(formDefinition);
     // Store in dynamodb
     await this.database.storeSubmission({

--- a/src/app/submission/SubmissionSchema.ts
+++ b/src/app/submission/SubmissionSchema.ts
@@ -22,6 +22,9 @@ export const SubmissionSchema = z.object({
   }),
   bsn: z.string().optional(),
   kvk: z.string().optional(),
+  metadata: z.object({
+    timestamp: z.array(z.number()),
+  }).passthrough(),
 });
 
 export const SubmissionPaymentSchema = z.object({

--- a/src/app/submission/test/MockDatabase.ts
+++ b/src/app/submission/test/MockDatabase.ts
@@ -24,6 +24,9 @@ export class MockDatabase implements Database {
       userId: parameters.userId,
       key: 'TDL123.001',
       pdf: 'submission.pdf',
+      dateSubmitted: '2023-12-23T11:58:52.670Z',
+      formName: 'bingoMeldenOfLoterijvergunningAanvragen',
+      formTitle: 'Bingo melden of loterijvergunning aanvragen',
     }];
   }
 }

--- a/src/app/submission/test/database.test.ts
+++ b/src/app/submission/test/database.test.ts
@@ -21,6 +21,9 @@ describe('Save object', () => {
           originalName: 'testattachment2.pdf',
         },
       ],
+      dateSubmitted: '2023-12-23T11:58:52.670Z',
+      formName: 'bingoMeldenOfLoterijvergunningAanvragen',
+      formTitle: 'Bingo melden of loterijvergunning aanvragen',
     })).toBeTruthy();
   });
 
@@ -71,11 +74,17 @@ describeIntegration('Dynamodb integration tests', () => {
       key: 'TDL10.002',
       pdf: 'submission.pdf',
       userId: '900222670',
+      dateSubmitted: '2023-12-23T11:58:52.670Z',
+      formName: 'bingoMeldenOfLoterijvergunningAanvragen',
+      formTitle: 'Bingo melden of loterijvergunning aanvragen',
     });
     expect(await database.storeSubmission({
       key: 'TDL10.001',
       pdf: 'submission.pdf',
       userId: '900222670',
+      dateSubmitted: '2023-12-23T11:58:52.670Z',
+      formName: 'bingoMeldenOfLoterijvergunningAanvragen',
+      formTitle: 'Bingo melden of loterijvergunning aanvragen',
     })).toBeTruthy();
   });
 

--- a/src/migrations/migration-2024-02-06-enrich-table.lambda.ts
+++ b/src/migrations/migration-2024-02-06-enrich-table.lambda.ts
@@ -142,7 +142,7 @@ export class Migration {
         const formTitle = formdefinitions?.[formNameLowerCased]?.title;
         let submissionDate;
         if (submission.metadata.timestamp) {
-          submissionDate = new Date(Date.UTC(...submission.metadata.timestamp as [number, number, number, number, number, number, number]));
+          submissionDate = new Date(Date.UTC(...submission.metadata.timestamp.slice(0, -1) as [number, number, number, number, number, number]));
         } else {
           this.info(`submission object for ${key} has no timestamp, using sns timestamp`);
           submissionDate = submission.snsTimeStamp;

--- a/src/migrations/migration-2024-02-06-enrich-table.lambda.ts
+++ b/src/migrations/migration-2024-02-06-enrich-table.lambda.ts
@@ -1,5 +1,6 @@
 import { AttributeValue, DynamoDBClient, ScanCommand, ScanCommandOutput, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
 import { S3Storage, Storage } from '../app/submission/Storage';
+import { dateArrayToDate } from '../utils/dateArrayToDate';
 
 /**
  * This is a one-time use function to migrate the dynamoDB table used for storing submissions. The following changes need to be performed:
@@ -142,7 +143,7 @@ export class Migration {
         const formTitle = formdefinitions?.[formNameLowerCased]?.title;
         let submissionDate;
         if (submission.metadata.timestamp) {
-          submissionDate = new Date(Date.UTC(...submission.metadata.timestamp.slice(0, -1) as [number, number, number, number, number, number]));
+          submissionDate = dateArrayToDate(submission.metadata.timestamp);
         } else {
           this.info(`submission object for ${key} has no timestamp, using sns timestamp`);
           submissionDate = submission.snsTimeStamp;

--- a/src/migrations/test/migration-2024-02-06-enrich-table.test.ts
+++ b/src/migrations/test/migration-2024-02-06-enrich-table.test.ts
@@ -136,8 +136,10 @@ describeIntegration('Dynamodb migration test', () => {
   test('can get new attributes for updated item after update', async() => {
     await new Migration(dynamoDBClient, tableName, storage).run(50, false);
     const command = getItemCommand(tableName, 'TDL17.957');
-    expect(await dynamoDBClient.send(command)).toHaveProperty('Item.dateSubmitted');
-    expect(await dynamoDBClient.send(command)).toHaveProperty('Item.formTitle');
+    const results = await dynamoDBClient.send(command);
+    expect(results).toHaveProperty('Item.dateSubmitted');
+    expect(results).toHaveProperty('Item.formTitle');
+    expect(results?.Item?.dateSubmitted?.S).toBe('2024-03-01T13:19:04.000Z');
   });
 
   test('dryrun does not actually update', async() => {

--- a/src/migrations/test/migration-2024-02-06-enrich-table.test.ts
+++ b/src/migrations/test/migration-2024-02-06-enrich-table.test.ts
@@ -139,7 +139,7 @@ describeIntegration('Dynamodb migration test', () => {
     const results = await dynamoDBClient.send(command);
     expect(results).toHaveProperty('Item.dateSubmitted');
     expect(results).toHaveProperty('Item.formTitle');
-    expect(results?.Item?.dateSubmitted?.S).toBe('2024-03-01T13:19:04.000Z');
+    expect(results?.Item?.dateSubmitted?.S).toBe('2024-02-01T13:19:04.000Z');
   });
 
   test('dryrun does not actually update', async() => {

--- a/src/utils/dateArrayToDate.ts
+++ b/src/utils/dateArrayToDate.ts
@@ -1,0 +1,20 @@
+/**
+ * Submissions have a 'timestamp' value of form [2024, 2, 1, 12, 14, 22, 123456]
+ * This function creates a javascript Date object out of an array of that form.
+ *
+ * @param inputArray number[]
+ * @returns `Date` converted date
+ */
+export function dateArrayToDate(inputArray: number[]): Date {
+  let dateArray: [number, number, number, number, number, number];
+  if (inputArray.length == 7) {
+    // Slice last element, unnecessary (sub-second precision is not required)
+    dateArray = inputArray.slice(0, -1) as [number, number, number, number, number, number];
+  } else {
+    throw Error('timestamp array expected to be 7 elements long');
+  }
+  // second element is month. Javascript expects a monthindex, 0-11, instead of 1-12. Modify
+  dateArray[1] = dateArray[1] - 1;
+  // Convert to timestamp (UTC) and then pass that timestamp to Date constructor
+  return new Date(Date.UTC(...dateArray));
+}

--- a/src/utils/test/dateArrayToDate.test.ts
+++ b/src/utils/test/dateArrayToDate.test.ts
@@ -1,0 +1,40 @@
+import { dateArrayToDate } from '../dateArrayToDate';
+
+describe('Passing an array of numbers', () => {
+  test('Returns a date if the array is valid', async () => {
+    const dateArray = [2024, 2, 1, 13, 19, 4, 11811229];
+    expect(dateArrayToDate(dateArray).toISOString()).toBe('2024-02-01T13:19:04.000Z');
+  });
+
+  test('Throws if the array is too short', async () => {
+    const dateArray = [2024, 2, 1, 13, 19, 4];
+    expect(() => { dateArrayToDate(dateArray); }).toThrow();
+  });
+
+
+  test('Throws if the array does not contain numbers', async () => {
+    const dateArray = [2024, 1, 'test', 13, 19, 4];
+    //@ts-ignore so we can test this;
+    expect(() => { dateArrayToDate(dateArray); }).toThrow();
+  });
+
+  test('Passing a date in January works', async () => {
+    const dateArray = [2024, 1, 1, 0, 0, 0, 0];
+    expect(dateArrayToDate(dateArray).toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  test('Passing a date in December works', async () => {
+    const dateArray = [2024, 12, 31, 0, 0, 0, 0];
+    expect(dateArrayToDate(dateArray).toISOString()).toBe('2024-12-31T00:00:00.000Z');
+  });
+
+  test('Passing a feb 29 in a year it exists works', async () => {
+    const dateArray = [2024, 2, 29, 0, 0, 0, 0];
+    expect(dateArrayToDate(dateArray).toISOString()).toBe('2024-02-29T00:00:00.000Z');
+  });
+
+  test('Passing a feb 29 in a year it does not exist returns march 1st', async () => {
+    const dateArray = [2025, 2, 29, 0, 0, 0, 0];
+    expect(dateArrayToDate(dateArray).toISOString()).toBe('2025-03-01T00:00:00.000Z');
+  });
+});


### PR DESCRIPTION
Adds metadata to newly stored submissions. (formName, title, and submittedDate). This is the same data as the migration would add, but this will now be added to all new submissions.

Also fixes an issue with calculating submission dates from submissions.