### PR TITLE
feat: Submission metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Deze applicatie is verantwoordelijk voor de opslag van formulierinzendingen, voor afnemers (Mijn Nijmegen) die deze moeten kunnen tonen aan de indiener. De applicatie is gesubscribed op het SNS-topic dat in [webformulieren](https://github.com/gemeentenijmegen/webformulieren) bestaat, en verwerkt inzendingen bij binnenkomst.
 
-Het is nog niet mogelijk ingezonden formulieren op te halen.
+Meer informatie onder [/docs](docs).

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,16 @@
+# Documentatie submission-storage oplossing
+
+In dit project wordt de opslag van formulierinzendingen geregeld. Deze opslag is additioneel aan de verwerking door processystemen. Voor het [webformulierenproject](https://github.com/webformulieren) is dit project een van meerdere subscribers/afnemers van inzendingen.
+
+## Opslag
+De `submissionSnsEventHandler`-functie is een subscriber op het webformulieren-submissions-SNS-topic in het webformulierenproject. Binnengekomen berichten worden geparsed, bestanden worden uit S3 opgehaald en in een eigen bucket opgeslagen, relevante metadata wordt in dynamoDB opgeslaagd met een referentie naar S3 (gekeyed op de inzender) zodat deze later op te halen is.
+
+## Toegang
+Er is een API-Gateway die toegang biedt tot inzendingen. Deze gaat gebruikt worden voor de ontsluiting in Mijn Nijmegen, en mogelijk later voor andere afnemers (managementportaal bijv.). Op dit moment is het mogelijk formulieren te 'listen' op userId.
+
+## Downloads van bestanden
+Omdat API Gateway een limiet van 10MB heeft, en we bestandsdownloads liever geen pad door lambda's laten afleggen, is een andere oplossing vereist voor de download van bestanden. Er wordt momenteel gewerkt aan een oplossing waarbij een Lambda@Edge-functie in Cloudfront authorisatie regelt voor toegang tot S3-files.[^1](#fn1)
+
+
+
+1: https://aws.amazon.com/blogs/networking-and-content-delivery/authorizationedge-how-to-use-lambdaedge-and-json-web-tokens-to-enhance-web-application-security/

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -63,7 +63,6 @@ export class Api extends Construct {
     });
     //PAste
     const plan = api.addUsagePlan('UsagePlanManagementApi', {
-      name: 'management',
       description: 'used for rate-limit and api key',
       throttle: {
         rateLimit: 5,
@@ -71,8 +70,7 @@ export class Api extends Construct {
       },
     });
     const apiKey = api.addApiKey('ApiKeyManagement', {
-      apiKeyName: 'ManagementApi',
-      description: 'gebruikt voor alle methods van management API',
+      description: 'gebruikt voor alle methods van submissions API',
     });
 
     //fix for removing/adding usage plans to workaround old bug https://github.com/aws/aws-cdk/pull/13817

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -1,0 +1,105 @@
+import { Duration } from 'aws-cdk-lib';
+import { LambdaIntegration, RestApi } from 'aws-cdk-lib/aws-apigateway';
+import { ITable, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { GetFormOverviewFunction } from './app/get-form-overview/getFormOverview-function';
+import { ListSubmissionsFunction } from './app/listSubmissions/listSubmissions-function';
+import { Statics } from './statics';
+
+export class Api extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const api = this.createApiWithApiKey();
+
+    const key = Key.fromKeyArn(this, 'key', StringParameter.valueForStringParameter(this, Statics.ssmDataKeyArn));
+
+    // IBucket requires encryption key, otherwise grant methods won't add the correct permissions
+    const storageBucket = Bucket.fromBucketAttributes(this, 'bucket', {
+      bucketArn: StringParameter.valueForStringParameter(this, Statics.ssmSubmissionBucketArn),
+      encryptionKey: key,
+    });
+
+    const downloadBucket = Bucket.fromBucketAttributes(this, 'downloadBucket', {
+      bucketArn: StringParameter.valueForStringParameter(this, Statics.ssmDownloadBucketArn),
+      encryptionKey: key,
+    });
+
+    const table = Table.fromTableAttributes(this, 'table', {
+      tableName: StringParameter.valueForStringParameter(this, Statics.ssmSubmissionTableName),
+      encryptionKey: key,
+    });
+
+    this.addListSubmissionsEndpoint(api, storageBucket, table);
+    this.addFormOverviewEndpoint(api, storageBucket, downloadBucket);
+  }
+
+  private addListSubmissionsEndpoint(api: RestApi, storageBucket: IBucket, table: ITable) {
+    const lambda = new ListSubmissionsFunction(this, 'list-submissions', {
+      environment: {
+        BUCKET_NAME: storageBucket.bucketName,
+        TABLE_NAME: table.tableName,
+      },
+    });
+    table.grantReadData(lambda);
+    storageBucket.grantRead(lambda);
+
+    const listSubmissionsEndpoint = api.root.addResource('submissions');
+    listSubmissionsEndpoint.addMethod('GET', new LambdaIntegration(lambda), {
+      apiKeyRequired: true,
+      requestParameters: {
+        'method.request.querystring.user_id': true,
+        'method.request.querystring.user_type': true,
+      },
+    });
+  }
+
+  private createApiWithApiKey() {
+    const api = new RestApi(this, 'api', {
+      description: 'api endpoints om submission storage data op te halen',
+    });
+    //PAste
+    const plan = api.addUsagePlan('UsagePlanManagementApi', {
+      name: 'management',
+      description: 'used for rate-limit and api key',
+      throttle: {
+        rateLimit: 5,
+        burstLimit: 10,
+      },
+    });
+    const apiKey = api.addApiKey('ApiKeyManagement', {
+      apiKeyName: 'ManagementApi',
+      description: 'gebruikt voor alle methods van management API',
+    });
+
+    //fix for removing/adding usage plans to workaround old bug https://github.com/aws/aws-cdk/pull/13817
+    plan.addApiKey(apiKey);
+
+    plan.addApiStage({
+      stage: api.deploymentStage,
+    });
+
+    return api;
+  }
+
+  private addFormOverviewEndpoint(api: RestApi, storageBucket: IBucket, downloadBucket: IBucket) {
+    const formOverviewFunction = new GetFormOverviewFunction(this, 'getFormOverview', {
+      environment: {
+        BUCKET_NAME: storageBucket.bucketName,
+        DOWNLOAD_BUCKET_NAME: downloadBucket.bucketName,
+      },
+      timeout: Duration.minutes(10),
+      memorySize: 1024,
+    });
+    storageBucket.grantRead(formOverviewFunction);
+    downloadBucket.grantReadWrite(formOverviewFunction);
+
+    const formOverviewApi = api.root.addResource('formoverview');
+    formOverviewApi.addMethod('GET', new LambdaIntegration(formOverviewFunction), {
+      apiKeyRequired: true,
+    });
+  }
+}

--- a/src/ApiStack.ts
+++ b/src/ApiStack.ts
@@ -1,15 +1,8 @@
 
-import { Duration, Stack, StackProps } from 'aws-cdk-lib';
-import { LambdaIntegration, RestApi } from 'aws-cdk-lib/aws-apigateway';
-import { Table } from 'aws-cdk-lib/aws-dynamodb';
-import { Key } from 'aws-cdk-lib/aws-kms';
-import { Bucket } from 'aws-cdk-lib/aws-s3';
-import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { GetFormOverviewFunction } from './app/get-form-overview/getFormOverview-function';
-import { ListSubmissionsFunction } from './app/listSubmissions/listSubmissions-function';
+import { Api } from './Api';
 import { Configurable } from './Configuration';
-import { Statics } from './statics';
 import { SubmissionSnsEventHandler } from './SubmissionSnsEventHandler';
 import { SubmissionsTopic } from './SubmissionsTopic';
 
@@ -18,7 +11,6 @@ interface ApiStackProps extends StackProps, Configurable {};
  * Contains all API-related resources.
  */
 export class ApiStack extends Stack {
-
   constructor(scope: Construct, id: string, props: ApiStackProps) {
     super(scope, id, props);
 
@@ -33,111 +25,6 @@ export class ApiStack extends Stack {
       topicArns: topicArns,
     });
 
-
-    const api = this.createApi();
-
-    //TODO: move later on
-    const formOverviewFunction = this.getFormOverviewFunction();
-    const formOverviewApi = api.root.addResource('formoverview');
-    formOverviewApi.addMethod('GET', new LambdaIntegration(formOverviewFunction), {
-      apiKeyRequired: true,
-      // requestParameters: {
-      //   'method.request.querystring.key': true,
-      // },
-    });
-
-    const listSubmissionsFunction = new ListSubmissionsLambda(this, 'listsubmissions');
-    const listSubmissionsEndpoint = api.root.addResource('submissions');
-    listSubmissionsEndpoint.addMethod('GET', new LambdaIntegration(listSubmissionsFunction.lambda), {
-      apiKeyRequired: true,
-      requestParameters: {
-        'method.request.querystring.user_id': true,
-        'method.request.querystring.user_type': true,
-      },
-    });
-  }
-
-  private createApi() {
-    const api = new RestApi(this, 'submissionStorageApi', {
-      description: 'api endpoints om submission storage data op te halen',
-    });
-    //PAste
-    const plan = api.addUsagePlan('UsagePlanManagementApi', {
-      name: 'management',
-      description: 'used for rate-limit and api key',
-      throttle: {
-        rateLimit: 5,
-        burstLimit: 10,
-      },
-    });
-    const apiKey = api.addApiKey('ApiKeyManagement', {
-      apiKeyName: 'ManagementApi',
-      description: 'gebruikt voor alle methods van management API',
-    });
-
-    //fix for removing/adding usage plans to workaround old bug https://github.com/aws/aws-cdk/pull/13817
-    plan.addApiKey(apiKey);
-
-    plan.addApiStage({
-      stage: api.deploymentStage,
-    });
-
-    return api;
-  }
-
-  private getFormOverviewFunction() {
-    const key = Key.fromKeyArn(this, 'key', StringParameter.valueForStringParameter(this, Statics.ssmDataKeyArn));
-
-    // IBucket requires encryption key, otherwise grant methods won't add the correct permissions
-    const storageBucket = Bucket.fromBucketAttributes(this, 'bucket', {
-      bucketArn: StringParameter.valueForStringParameter(this, Statics.ssmSubmissionBucketArn),
-      encryptionKey: key,
-    });
-
-    const downloadBucket = Bucket.fromBucketAttributes(this, 'downloadBucket', {
-      bucketArn: StringParameter.valueForStringParameter(this, Statics.ssmDownloadBucketArn),
-      encryptionKey: key,
-    });
-
-
-    const formOverviewFunction = new GetFormOverviewFunction(this, 'getFormOverview', {
-      environment: {
-        BUCKET_NAME: storageBucket.bucketName,
-        DOWNLOAD_BUCKET_NAME: downloadBucket.bucketName,
-      },
-      timeout: Duration.minutes(10),
-      memorySize: 1024,
-    });
-    storageBucket.grantRead(formOverviewFunction);
-    downloadBucket.grantReadWrite(formOverviewFunction);
-    return formOverviewFunction;
-  }
-}
-
-
-class ListSubmissionsLambda extends Construct {
-  lambda: ListSubmissionsFunction;
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-
-    // IBucket requires encryption key, otherwise grant methods won't add the correct permissions
-    const key = Key.fromKeyArn(this, 'key', StringParameter.valueForStringParameter(this, Statics.ssmDataKeyArn));
-    const storageBucket = Bucket.fromBucketAttributes(this, 'bucket', {
-      bucketArn: StringParameter.valueForStringParameter(this, Statics.ssmSubmissionBucketArn),
-      encryptionKey: key,
-    });
-
-    const table = Table.fromTableAttributes(this, 'table', {
-      tableName: StringParameter.valueForStringParameter(this, Statics.ssmSubmissionTableName),
-      encryptionKey: key,
-    });
-    this.lambda = new ListSubmissionsFunction(this, 'list-submissions', {
-      environment: {
-        BUCKET_NAME: storageBucket.bucketName,
-        TABLE_NAME: table.tableName,
-      },
-    });
-    table.grantReadData(this.lambda);
-    storageBucket.grantRead(this.lambda);
+    new Api(this, 'api');
   }
 }

--- a/src/SubmissionSnsEventHandler.ts
+++ b/src/SubmissionSnsEventHandler.ts
@@ -16,6 +16,14 @@ import { Statics } from './statics';
 interface SubmissionSnsEventHandlerProps {
   topicArns: string[];
 }
+
+/**
+ * The submissionsSnsEventHandler receives form submissions
+ *
+ * This handler is subscribed to the SNS Topic(s) form submissions are
+ * submitted to. It handles receiving the submission, parsing it, saving
+ * metadata to DynamoDB and storing attachments / PDF's to S3.
+ */
 export class SubmissionSnsEventHandler extends Construct {
   private role?: Role;
   public lambda: Function;

--- a/src/app/listSubmissions/ListSubmissionsRequestHandler.ts
+++ b/src/app/listSubmissions/ListSubmissionsRequestHandler.ts
@@ -1,15 +1,13 @@
 import { ApiGatewayV2Response, Response } from '@gemeentenijmegen/apigateway-http/lib/V2/Response';
 import { EventParameters } from './parsedEvent';
 import { Database, DynamoDBDatabase } from '../submission/Database';
-import { S3Storage, Storage } from '../submission/Storage';
 
 export class ListSubmissionsRequestHandler {
 
   private database: Database;
-  private storage: Storage;
   constructor() {
     const environment = this.getEvironmentVariables();
-    [this.database, this.storage] = this.setup(environment);
+    [this.database] = this.setup(environment);
   }
 
   private getEvironmentVariables() {
@@ -29,41 +27,15 @@ export class ListSubmissionsRequestHandler {
    * Check for required environment variables, and create
    * storage and database objects to pass to handler.
    */
-  private setup(environment: { tableName: string; bucketName: string }): [Database, Storage] {
+  private setup(environment: { tableName: string }): [Database] {
     return [
       new DynamoDBDatabase(environment.tableName),
-      new S3Storage(environment.bucketName),
     ];
   }
 
   async handleRequest(parameters: EventParameters): Promise<ApiGatewayV2Response> {
     const results = await this.database.listSubmissions({ userId: parameters.userId });
-    const submissions = await this.getBucketObjects(results.map(result => `${result.key}/submission.json`));
-    const resultObjects = results.map((result) => {
-      if (submissions[result.key]) {
-        return {
-          ...result,
-          formName: submissions[result.key].formTypeId,
-          date: new Date(Date.UTC(...submissions[result.key].metadata.timestamp as [number, number, number, number, number, number, number])),
-        };
-      } else {
-        return results;
-      }
-    });
-    return Response.json(resultObjects);
+    return Response.json(results);
   }
 
-  async getBucketObjects(keys: string[]) {
-    const objects = await this.storage.getBatch(keys);
-    const submissions: any = {};
-    for (const object of objects) {
-      if (object.Body) {
-        const bodyString = await object.Body.transformToString();
-        const objectJson = JSON.parse(bodyString);
-        const submission = JSON.parse(objectJson.Message);
-        submissions[submission.reference] = submission;
-      }
-    }
-    return submissions;
-  }
 }

--- a/src/app/listSubmissions/test/listSubmissionsRequestHandler.test.ts
+++ b/src/app/listSubmissions/test/listSubmissionsRequestHandler.test.ts
@@ -1,24 +1,23 @@
-import * as snsSample from '../../submission/test/samples/sns.sample.json';
 import { ListSubmissionsRequestHandler } from '../ListSubmissionsRequestHandler';
 
 const listResults = [{
-  key: 'TDL17.957',
-  pdf: 'TDL17.957/submission.pdf',
-}];
-
-const expectedListResults = [{
+  userId: '900222670',
   key: 'TDL17.957',
   pdf: 'TDL17.957/submission.pdf',
   formName: 'bingoMeldenOfLoterijvergunningAanvragen',
-  date: '2024-03-01T16:35:55.229Z',
+  dateSubmitted: '2024-03-01T16:35:55.229Z',
+  formTitle: 'Bingo melden',
 }];
 
-const getObjectMock = (file:any) => ({
-  Body: {
-    // Stringify the file to simulate the AWS getObject response
-    transformToString: () => Promise.resolve(JSON.stringify(file)),
-  },
-});
+const expectedListResults = [{
+  userId: '900222670',
+  key: 'TDL17.957',
+  pdf: 'TDL17.957/submission.pdf',
+  formName: 'bingoMeldenOfLoterijvergunningAanvragen',
+  dateSubmitted: '2024-03-01T16:35:55.229Z',
+  formTitle: 'Bingo melden',
+}];
+
 
 jest.mock('../../submission/Database', () => {
 
@@ -27,18 +26,6 @@ jest.mock('../../submission/Database', () => {
       return {
         listSubmissions: async () => {
           return listResults;
-        },
-      };
-    }),
-  };
-});
-
-jest.mock('../../submission/Storage', () => {
-  return {
-    S3Storage: jest.fn(() => {
-      return {
-        getBatch: async () => {
-          return [getObjectMock(snsSample.Records[0].Sns)];
         },
       };
     }),

--- a/src/app/submission/Database.ts
+++ b/src/app/submission/Database.ts
@@ -19,7 +19,6 @@ const dynamoDBStringSchema = z.object({
 const submissionTableItemSchema = z.object({
   pk: dynamoDBStringSchema,
   sk: dynamoDBStringSchema,
-  key: dynamoDBStringSchema,
   pdfKey: dynamoDBStringSchema,
   dateSubmitted: dynamoDBStringSchema,
   formName: dynamoDBStringSchema,

--- a/src/app/submission/Database.ts
+++ b/src/app/submission/Database.ts
@@ -1,16 +1,37 @@
 import { DynamoDBClient, PutItemCommand, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { z } from 'zod';
 import { hashString } from './hash';
-import { s3Object } from './s3Object';
 
 export interface SubmissionData {
   userId: string;
   key: string;
   pdf: string;
-  attachments?: s3Object[];
+  attachments?: string[];
   dateSubmitted?: string;
   formName?: string;
   formTitle?: string;
 }
+
+const dynamoDBStringSchema = z.object({
+  S: z.string(),
+});
+
+const submissionTableItemSchema = z.object({
+  pk: dynamoDBStringSchema,
+  sk: dynamoDBStringSchema,
+  key: dynamoDBStringSchema,
+  pdfKey: dynamoDBStringSchema,
+  dateSubmitted: dynamoDBStringSchema,
+  formName: dynamoDBStringSchema,
+  formTitle: dynamoDBStringSchema,
+  attachments: z.object({
+    L: z.array(dynamoDBStringSchema),
+  }),
+});
+
+const submissionTableItemsSchema = z.object({
+  Items: z.array(submissionTableItemSchema),
+});
 
 export interface ListSubmissionParameters {
   userId: string;
@@ -61,7 +82,7 @@ export class DynamoDBDatabase implements Database {
       KeyConditionExpression: '#pk = :id',
     });
     try {
-      const results = await this.client.send(queryCommand);
+      const results = submissionTableItemsSchema.parse(await this.client.send(queryCommand));
       const items = results.Items?.map((item) => {
         return {
           userId: parameters.userId,
@@ -70,6 +91,7 @@ export class DynamoDBDatabase implements Database {
           dateSubmitted: item?.dateSubmitted.S ?? '',
           formName: item?.formName.S ?? '',
           formTitle: item?.formTitle.S ?? '',
+          attachments: item.attachments.L.map(attachment => attachment.S),
         };
       }) ?? [];
       return items;
@@ -98,7 +120,7 @@ export function dynamoDBItem(pk: string, sk: string, submission: SubmissionData)
   if (submission.attachments) {
     item.attachments = {
       L: submission.attachments?.map((attachment) => {
-        return { S: attachment.originalName };
+        return { S: attachment };
       }),
     };
   };

--- a/src/app/submission/Submission.ts
+++ b/src/app/submission/Submission.ts
@@ -28,7 +28,7 @@ export class Submission {
 
   public bsn?: string;
   public kvk?: string;
-  public pdf?: s3Object;
+  public pdf?: { bucket: string; key: string };
   public attachments?: s3Object[];
   public key?: string;
 
@@ -74,7 +74,7 @@ export class Submission {
    *
    * @returns `[s3Object]`
    */
-  async getAttachments(): Promise<{ bucket: string; key: string; originalName?: string | undefined }[]> {
+  async getAttachments(): Promise<s3Object[]> {
     const filesObjects = getSubObjectsWithKey(this.parsedSubmission!.data, 'bucketName');
     return filesObjects.map((file: any) => {
       const result = {
@@ -129,7 +129,7 @@ export class Submission {
       userId: this.userId(),
       key: this.key,
       pdf: pdfKey,
-      attachments: this.attachments,
+      attachments: this.attachments?.map(attachment => attachment.originalName),
       dateSubmitted: dateSubmitted?.toISOString(),
       formName: this.parsedSubmission.formTypeId,
       formTitle: parsedDefinition.title,

--- a/src/app/submission/s3Object.ts
+++ b/src/app/submission/s3Object.ts
@@ -4,6 +4,6 @@ export interface s3Object {
   /** the key (entire path) to the file in S3 */
   key: string;
   /** The filename this file was uploaded as */
-  originalName?: string;
+  originalName: string;
 
 }

--- a/src/app/submission/test/database.test.ts
+++ b/src/app/submission/test/database.test.ts
@@ -15,11 +15,7 @@ describe('Save object', () => {
       key: 'TDL.1234',
       pdf: 'test.pdf',
       attachments: [
-        {
-          bucket: 'testbucket',
-          key: 'testattachment.pdf',
-          originalName: 'testattachment2.pdf',
-        },
+        'testattachment2.pdf',
       ],
       dateSubmitted: '2023-12-23T11:58:52.670Z',
       formName: 'bingoMeldenOfLoterijvergunningAanvragen',


### PR DESCRIPTION
- remove unnecessary s3 lookups in list submissions-endpoint
- get metadata in list submissions endpoint
- adds readme
- refactors API stack:
Move most functions in the ApiStack to a separate
Api-construct. This construct is responsible for
creating the API Gateway and attached functions.

Since we move them to a different construct, this
will result in recreation of resources. Since all
of these are stateless, no impact is expected.

The API key will be recreated, but since no
production consumers of this API exist yet, this
isn't an issue.