### PR TITLE
feat: revert global secondary index and unittest fix

### DIFF
--- a/src/StorageStack.ts
+++ b/src/StorageStack.ts
@@ -65,11 +65,6 @@ export class StorageStack extends Stack {
       encryptionKey: key,
       encryption: TableEncryption.CUSTOMER_MANAGED,
     });
-    table.addGlobalSecondaryIndex({
-      indexName: 'formNameIndex',
-      partitionKey: { name: 'formName', type: AttributeType.STRING },
-      sortKey: { name: 'dateSubmitted', type: AttributeType.STRING },
-    });
     this.addArnToParameterStore('tableParam', table.tableArn, Statics.ssmSubmissionTableArn);
     this.addArnToParameterStore('tableNameParam', table.tableName, Statics.ssmSubmissionTableName);
 

--- a/src/app/submission/test/submissionHandler.test.ts
+++ b/src/app/submission/test/submissionHandler.test.ts
@@ -4,6 +4,18 @@ import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-sec
 import { mockClient } from 'aws-sdk-client-mock';
 import * as snsSample from './samples/sns.sample.json';
 import { SubmissionHandler } from '../SubmissionHandler';
+
+let mockDefinition = jest.fn().mockResolvedValue({ title: 'testTitel', name: 'testName' });
+jest.mock('../FormConnector', () => {
+  return {
+    FormIoFormConnector: jest.fn(() => {
+      return {
+        definition: mockDefinition,
+      };
+    }),
+  };
+});
+
 const secretsMock = mockClient(SecretsManagerClient);
 const dbMock = mockClient(DynamoDBClient);
 const s3Mock = mockClient(S3Client);

--- a/src/app/submission/test/submissionHandler.test.ts
+++ b/src/app/submission/test/submissionHandler.test.ts
@@ -4,18 +4,6 @@ import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-sec
 import { mockClient } from 'aws-sdk-client-mock';
 import * as snsSample from './samples/sns.sample.json';
 import { SubmissionHandler } from '../SubmissionHandler';
-let mockDefinition = jest.fn().mockResolvedValue({ title: 'testTitel', name: 'testName' });
-jest.mock('../FormConnector', () => {
-
-  return {
-    FormIoFormConnector: jest.fn(() => {
-      return {
-        definition: mockDefinition,
-      };
-    }),
-  };
-
-});
 const secretsMock = mockClient(SecretsManagerClient);
 const dbMock = mockClient(DynamoDBClient);
 const s3Mock = mockClient(S3Client);


### PR DESCRIPTION
Reverts GemeenteNijmegen/webformulieren-submissionstorage#125

Reverts only global secondary index.
Unit test mock required to merge PR with succeeding tests.