### PR TITLE
feat: #1166 ttl lifecycle for s3 submissions set to two years instead…

### DIFF
--- a/src/StorageStack.ts
+++ b/src/StorageStack.ts
@@ -30,7 +30,7 @@ export class StorageStack extends Stack {
       objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
       lifecycleRules: [
         {
-          expiration: Duration.days(365),
+          expiration: Duration.days(730), //Two Years
         },
       ],
       encryptionKey: key,


### PR DESCRIPTION
#1166 TTL lifecycle for bucket set to 730 days - two years - instead of one year.
Dynamodb ttl not needed, attribute ttl not added to db items