### PR TITLE
feat: update dynamodb query after migration to retrieve person and org

### DIFF
--- a/src/app/listSubmissions/ListSubmissionsRequestHandler.ts
+++ b/src/app/listSubmissions/ListSubmissionsRequestHandler.ts
@@ -36,9 +36,9 @@ export class ListSubmissionsRequestHandler {
   async handleRequest(parameters: EventParameters): Promise<ApiGatewayV2Response> {
     let results;
     if (parameters.key) {
-      results = await this.database.getSubmission({ userId: parameters.userId, key: parameters.key });
+      results = await this.database.getSubmission({ userId: parameters.userId, userType: parameters.userType, key: parameters.key });
     } else {
-      results = await this.database.listSubmissions({ userId: parameters.userId });
+      results = await this.database.listSubmissions({ userId: parameters.userId, userType: parameters.userType });
     }
     return Response.json(results);
   }

--- a/src/app/submission/Submission.ts
+++ b/src/app/submission/Submission.ts
@@ -132,6 +132,7 @@ export class Submission {
     // Store in dynamodb
     await this.database.storeSubmission({
       userId: this.userId(),
+      userType: this.userType(),
       key: this.key,
       pdf: pdfKey,
       attachments: this.attachments?.map(attachment => attachment.originalName),
@@ -159,6 +160,27 @@ export class Submission {
       return this.bsn;
     } else if (this.kvk) {
       return this.kvk;
+    } else {
+      return 'anonymous';
+    }
+  }
+
+  /**
+   * Get the userid for this submission.
+   *
+   * Submissions can be done with bsn, kvk
+   * or anonymous (we ignore other logins for now).
+   * We store all submissions, but won't be able
+   * to retrieve anonymous submissions for regular
+   * users.
+   *
+   * @returns bsn or kvk or 'anonymous'
+   */
+  private userType() {
+    if (this.bsn) {
+      return 'person';
+    } else if (this.kvk) {
+      return 'organisation';
     } else {
       return 'anonymous';
     }

--- a/src/app/submission/test/MockDatabase.ts
+++ b/src/app/submission/test/MockDatabase.ts
@@ -14,6 +14,7 @@ export class MockDatabase implements Database {
   async getSubmission(parameters: GetSubmissionParameters): Promise<SubmissionData> {
     return {
       userId: parameters.userId,
+      userType: parameters.userType,
       key: 'TDL123.001',
       pdf: 'submission.pdf',
       dateSubmitted: '2023-12-23T11:58:52.670Z',
@@ -35,6 +36,7 @@ export class MockDatabase implements Database {
   async listSubmissions(parameters: ListSubmissionParameters): Promise<SubmissionData[]> {
     return [{
       userId: parameters.userId,
+      userType: parameters.userType,
       key: 'TDL123.001',
       pdf: 'submission.pdf',
       dateSubmitted: '2023-12-23T11:58:52.670Z',

--- a/src/app/submission/test/database.test.ts
+++ b/src/app/submission/test/database.test.ts
@@ -13,6 +13,7 @@ describe('Save object', () => {
     const db = new MockDatabase('mockTable');
     expect(await db.storeSubmission({
       userId: 'testuser',
+      userType: 'person',
       key: 'TDL.1234',
       pdf: 'test.pdf',
       attachments: [
@@ -28,6 +29,7 @@ describe('Save object', () => {
     const db = new MockDatabase('mockTable');
     expect(await db.listSubmissions({
       userId: 'testuser',
+      userType: 'person',
     })).toBeTruthy();
   });
 });

--- a/src/migrations/test/migration-2024-02-06-enrich-table.test.ts
+++ b/src/migrations/test/migration-2024-02-06-enrich-table.test.ts
@@ -198,6 +198,7 @@ async function prefillDatabase(database: DynamoDBDatabase, items: number, startA
       key: `TDL17.${index}`,
       pdf: generateRandomString(10),
       userId: '900222670',
+      userType: 'person',
     });
   }
 
@@ -205,6 +206,7 @@ async function prefillDatabase(database: DynamoDBDatabase, items: number, startA
     key: 'TDL17.957',
     pdf: generateRandomString(1000),
     userId: '900222670',
+    userType: 'person',
   });
 }
 

--- a/src/migrations/test/migration-2024-02-06-enrich-table.test.ts
+++ b/src/migrations/test/migration-2024-02-06-enrich-table.test.ts
@@ -1,15 +1,14 @@
-// import * as crypto from 'crypto';
-// import { CreateTableCommand, DeleteTableCommand, DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb';
-// import { S3Client } from '@aws-sdk/client-s3';
+import * as crypto from 'crypto';
+import { CreateTableCommand, DeleteTableCommand, DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb';
+import { S3Storage } from '@gemeentenijmegen/utils';
 // eslint-disable-next-line import/no-extraneous-dependencies
-// import { S3Storage } from '@gemeentenijmegen/utils';
-// import { DockerComposeEnvironment, StartedDockerComposeEnvironment, Wait } from 'testcontainers';
+import { DockerComposeEnvironment, StartedDockerComposeEnvironment, Wait } from 'testcontainers';
 import * as formDefinitionSample from './sample-formdefinition.json';
 import * as submissionSampleNoTimestamp from './sample-submission-no-timestamp.json';
-// import { DynamoDBDatabase } from '../../app/submission/Database';
+import { DynamoDBDatabase } from '../../app/submission/Database';
 import * as snsSample from '../../app/submission/test/samples/sns.sample.json';
-// import { describeIntegration } from '../../app/test-utils/describeIntegration';
-// import { Migration, handler } from '../migration-2024-02-06-enrich-table.lambda';
+import { describeIntegration } from '../../app/test-utils/describeIntegration';
+import { Migration, handler } from '../migration-2024-02-06-enrich-table.lambda';
 
 
 const getObjectMock = (file:any) => ({
@@ -42,173 +41,174 @@ jest.mock('@gemeentenijmegen/utils', () => {
 test('Migration tests temporarily disabled', () => {
   console.warn('Migration tests temporarily disabled due to testcontainers localstack giving wrap ansi module errors');
 });
-// describeIntegration('Dynamodb migration test', () => {
-//   const composeFilePath = '/Users/joostvanderborg/Developer/webformulieren-submissionstorage/src/app/submission/test/';
-//   const composeFile = 'docker-compose-dynamodb.yml';
-//   let environment: StartedDockerComposeEnvironment;
 
-//   const dynamoDBClient = new DynamoDBClient({
-//     endpoint: 'http://localhost:8000',
-//     credentials: {
-//       accessKeyId: 'dummy',
-//       secretAccessKey: 'dummy',
-//     },
-//   });
+describeIntegration('Dynamodb migration test', () => {
+  const composeFilePath = '/Users/joostvanderborg/Developer/webformulieren-submissionstorage/src/app/submission/test/';
+  const composeFile = 'docker-compose-dynamodb.yml';
+  let environment: StartedDockerComposeEnvironment;
 
-//   const tableName = 'submissions-local';
-//   const database = new DynamoDBDatabase(tableName, { dynamoDBClient });
-//   const storage = new S3Storage('dummybucket');
+  const dynamoDBClient = new DynamoDBClient({
+    endpoint: 'http://localhost:8000',
+    credentials: {
+      accessKeyId: 'dummy',
+      secretAccessKey: 'dummy',
+    },
+  });
 
-//   beforeAll(async() => {
-//     if (!process.env.DEBUG) {
-//       console.debug = jest.fn();
-//     }
+  const tableName = 'submissions-local';
+  const database = new DynamoDBDatabase(tableName, { dynamoDBClient });
+  const storage = new S3Storage('dummybucket');
 
-//     environment = await new DockerComposeEnvironment(composeFilePath, composeFile)
-//       .withWaitStrategy('dynamodb-local', Wait.forLogMessage('CorsParams: null'))
-//       .up();
-//   }, 60000); // long timeout, can start docker image
+  beforeAll(async() => {
+    if (!process.env.DEBUG) {
+      console.debug = jest.fn();
+    }
 
-//   afterAll(async() => {
-//     console.debug('bringing environment down');
-//     await environment.down({ timeout: 10000 });
-//   });
+    environment = await new DockerComposeEnvironment(composeFilePath, composeFile)
+      .withWaitStrategy('dynamodb-local', Wait.forLogMessage('CorsParams: null'))
+      .up();
+  }, 60000); // long timeout, can start docker image
 
-//   beforeEach( async () => {
-//     const command = new CreateTableCommand({
-//       TableName: tableName,
-//       AttributeDefinitions: [
-//         {
-//           AttributeName: 'pk',
-//           AttributeType: 'S',
-//         }, {
-//           AttributeName: 'sk',
-//           AttributeType: 'S',
-//         },
-//       ],
-//       KeySchema: [
-//         {
-//           AttributeName: 'pk',
-//           KeyType: 'HASH',
-//         },
-//         {
-//           AttributeName: 'sk',
-//           KeyType: 'RANGE',
-//         },
-//       ],
-//       ProvisionedThroughput: {
-//         ReadCapacityUnits: 1,
-//         WriteCapacityUnits: 1,
-//       },
-//     });
+  afterAll(async() => {
+    console.debug('bringing environment down');
+    await environment.down({ timeout: 10000 });
+  });
 
-//     await dynamoDBClient.send(command);
-//     await prefillDatabase(database, 10);
-//   });
+  beforeEach( async () => {
+    const command = new CreateTableCommand({
+      TableName: tableName,
+      AttributeDefinitions: [
+        {
+          AttributeName: 'pk',
+          AttributeType: 'S',
+        }, {
+          AttributeName: 'sk',
+          AttributeType: 'S',
+        },
+      ],
+      KeySchema: [
+        {
+          AttributeName: 'pk',
+          KeyType: 'HASH',
+        },
+        {
+          AttributeName: 'sk',
+          KeyType: 'RANGE',
+        },
+      ],
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 1,
+        WriteCapacityUnits: 1,
+      },
+    });
 
-//   afterEach(async () => {
-//     const command = new DeleteTableCommand({
-//       TableName: tableName,
-//     });
+    await dynamoDBClient.send(command);
+    await prefillDatabase(database, 10);
+  });
 
-//     console.debug('removing table');
-//     await dynamoDBClient.send(command);
-//   });
+  afterEach(async () => {
+    const command = new DeleteTableCommand({
+      TableName: tableName,
+    });
 
-//   test('handler returns', async() => {
-//     process.env = {
-//       ...process.env,
-//       TABLE_NAME: 'dummytable',
-//       BUCKET_NAME: 'dummybucket',
-//     };
-//     expect(handler({ runlive: 'true' })).toBeTruthy();
-//   });
+    console.debug('removing table');
+    await dynamoDBClient.send(command);
+  });
 
-//   test('can create migration', async() => {
-//     expect(new Migration(dynamoDBClient, tableName, storage)).toBeTruthy();
-//   });
+  test('handler returns', async() => {
+    process.env = {
+      ...process.env,
+      TABLE_NAME: 'dummytable',
+      BUCKET_NAME: 'dummybucket',
+    };
+    expect(handler({ runlive: 'true' })).toBeTruthy();
+  });
 
-//   test('can perform update', async() => {
-//     await prefillDatabase(database, 20000, 2000);
-//     const migration = new Migration(dynamoDBClient, tableName, storage);
-//     const result = await migration.run(50, false);
-//     expect(result).toBeTruthy();
-//   }, 240000);
+  test('can create migration', async() => {
+    expect(new Migration(dynamoDBClient, tableName, storage)).toBeTruthy();
+  });
 
-//   test('can get new attributes for updated item after update', async() => {
-//     await new Migration(dynamoDBClient, tableName, storage).run(50, false);
-//     const command = getItemCommand(tableName, 'TDL17.957');
-//     const results = await dynamoDBClient.send(command);
-//     expect(results).toHaveProperty('Item.dateSubmitted');
-//     expect(results).toHaveProperty('Item.formTitle');
-//     expect(results?.Item?.dateSubmitted?.S).toBe('2024-02-01T13:19:04.000Z');
-//   });
+  test('can perform update', async() => {
+    await prefillDatabase(database, 20000, 2000);
+    const migration = new Migration(dynamoDBClient, tableName, storage);
+    const result = await migration.run(50, false);
+    expect(result).toBeTruthy();
+  }, 240000);
 
-//   test('dryrun does not actually update', async() => {
-//     await new Migration(dynamoDBClient, tableName, storage).run(50, true);
-//     const command = getItemCommand(tableName, 'TDL17.957');
-//     expect(await dynamoDBClient.send(command)).not.toHaveProperty('Item.dateSubmitted');
-//     expect(await dynamoDBClient.send(command)).not.toHaveProperty('Item.formTitle');
-//   });
+  test('can get new attributes for updated item after update', async() => {
+    await new Migration(dynamoDBClient, tableName, storage).run(50, false);
+    const command = getItemCommand(tableName, 'TDL17.957');
+    const results = await dynamoDBClient.send(command);
+    expect(results).toHaveProperty('Item.dateSubmitted');
+    expect(results).toHaveProperty('Item.formTitle');
+    expect(results?.Item?.dateSubmitted?.S).toBe('2024-02-01T13:19:04.000Z');
+  });
 
-//   test('item without S3 item shouldnt have been updated but still exist', async() => {
-//     await new Migration(dynamoDBClient, tableName, storage).run(50, false);
-//     const command = getItemCommand(tableName, 'TDL17.2');
-//     expect(await dynamoDBClient.send(command)).toHaveProperty('Item.pdfKey');
-//     expect(await dynamoDBClient.send(command)).not.toHaveProperty('Item.dateSubmitted');
-//   });
+  test('dryrun does not actually update', async() => {
+    await new Migration(dynamoDBClient, tableName, storage).run(50, true);
+    const command = getItemCommand(tableName, 'TDL17.957');
+    expect(await dynamoDBClient.send(command)).not.toHaveProperty('Item.dateSubmitted');
+    expect(await dynamoDBClient.send(command)).not.toHaveProperty('Item.formTitle');
+  });
 
-//   test('item without timestamp in submission uses sns timestamp', async() => {
-//     await new Migration(dynamoDBClient, tableName, storage).run(50, false);
-//     const command = getItemCommand(tableName, 'TDL17.1');
-//     expect(await dynamoDBClient.send(command)).toHaveProperty('Item.pdfKey');
-//     expect(await dynamoDBClient.send(command)).toHaveProperty('Item.dateSubmitted');
-//   });
+  test('item without S3 item shouldnt have been updated but still exist', async() => {
+    await new Migration(dynamoDBClient, tableName, storage).run(50, false);
+    const command = getItemCommand(tableName, 'TDL17.2');
+    expect(await dynamoDBClient.send(command)).toHaveProperty('Item.pdfKey');
+    expect(await dynamoDBClient.send(command)).not.toHaveProperty('Item.dateSubmitted');
+  });
 
-//   test('Running migration twice should result in same table', async() => {
-//     const consoleSpy = jest.spyOn(console, 'info');
-//     await new Migration(dynamoDBClient, tableName, storage).run(50, false);
-//     expect(consoleSpy).toHaveBeenCalledWith('Updating 2 items in dynamoDB');
-//     const command = getItemCommand(tableName, 'TDL17.2');
-//     expect(await dynamoDBClient.send(command)).toHaveProperty('Item.pdfKey');
-//     expect(await dynamoDBClient.send(command)).not.toHaveProperty('Item.dateSubmitted');
-//     await new Migration(dynamoDBClient, tableName, storage).run(50, false);
-//     expect(consoleSpy).toHaveBeenCalledWith('Updating 0 items in dynamoDB');
-//     const secondCommand = getItemCommand(tableName, 'TDL17.957');
-//     expect(await dynamoDBClient.send(secondCommand)).toHaveProperty('Item.dateSubmitted');
-//     expect(await dynamoDBClient.send(secondCommand)).toHaveProperty('Item.formTitle');
-//   });
-// });
+  test('item without timestamp in submission uses sns timestamp', async() => {
+    await new Migration(dynamoDBClient, tableName, storage).run(50, false);
+    const command = getItemCommand(tableName, 'TDL17.1');
+    expect(await dynamoDBClient.send(command)).toHaveProperty('Item.pdfKey');
+    expect(await dynamoDBClient.send(command)).toHaveProperty('Item.dateSubmitted');
+  });
 
-// function getItemCommand(tableName: string, itemKey: string) {
-//   return new GetItemCommand({
-//     Key: {
-//       pk: { S: 'USER#L835xGBbKWV6fKX226xP3/X3vU/JanfcDFutJXfyvB4=' },
-//       sk: { S: itemKey },
-//     },
-//     TableName: tableName,
-//   });
-// }
+  test('Running migration twice should result in same table', async() => {
+    const consoleSpy = jest.spyOn(console, 'info');
+    await new Migration(dynamoDBClient, tableName, storage).run(50, false);
+    expect(consoleSpy).toHaveBeenCalledWith('Updating 2 items in dynamoDB');
+    const command = getItemCommand(tableName, 'TDL17.2');
+    expect(await dynamoDBClient.send(command)).toHaveProperty('Item.pdfKey');
+    expect(await dynamoDBClient.send(command)).not.toHaveProperty('Item.dateSubmitted');
+    await new Migration(dynamoDBClient, tableName, storage).run(50, false);
+    expect(consoleSpy).toHaveBeenCalledWith('Updating 0 items in dynamoDB');
+    const secondCommand = getItemCommand(tableName, 'TDL17.957');
+    expect(await dynamoDBClient.send(secondCommand)).toHaveProperty('Item.dateSubmitted');
+    expect(await dynamoDBClient.send(secondCommand)).toHaveProperty('Item.formTitle');
+  });
+});
 
-// // Be able to fill up the db with enough data to have the scan be paginated (1MB per page)
-// async function prefillDatabase(database: DynamoDBDatabase, items: number, startAt?: number) {
-//   startAt = startAt ?? 0;
-//   for (let index = startAt; index < items + startAt; index++) {
-//     await database.storeSubmission({
-//       key: `TDL17.${index}`,
-//       pdf: generateRandomString(10),
-//       userId: '900222670',
-//     });
-//   }
+function getItemCommand(tableName: string, itemKey: string) {
+  return new GetItemCommand({
+    Key: {
+      pk: { S: 'USER#L835xGBbKWV6fKX226xP3/X3vU/JanfcDFutJXfyvB4=' },
+      sk: { S: itemKey },
+    },
+    TableName: tableName,
+  });
+}
 
-//   await database.storeSubmission({
-//     key: 'TDL17.957',
-//     pdf: generateRandomString(1000),
-//     userId: '900222670',
-//   });
-// }
+// Be able to fill up the db with enough data to have the scan be paginated (1MB per page)
+async function prefillDatabase(database: DynamoDBDatabase, items: number, startAt?: number) {
+  startAt = startAt ?? 0;
+  for (let index = startAt; index < items + startAt; index++) {
+    await database.storeSubmission({
+      key: `TDL17.${index}`,
+      pdf: generateRandomString(10),
+      userId: '900222670',
+    });
+  }
 
-// /** Create arbitrary strings, useful for filling up dynamodb */
-// function generateRandomString(length: number) {
-//   return crypto.randomBytes(length).toString('hex');
-// }
+  await database.storeSubmission({
+    key: 'TDL17.957',
+    pdf: generateRandomString(1000),
+    userId: '900222670',
+  });
+}
+
+/** Create arbitrary strings, useful for filling up dynamodb */
+function generateRandomString(length: number) {
+  return crypto.randomBytes(length).toString('hex');
+}

--- a/src/migrations/test/migration-2024-11-06-fix-kvk.test.ts
+++ b/src/migrations/test/migration-2024-11-06-fix-kvk.test.ts
@@ -233,18 +233,21 @@ async function prefillDatabase(database: DynamoDBDatabase, _items: number, start
     key: 'TDL17.100',
     pdf: generateRandomString(1000),
     userId: '69599084',
+    userType: 'organisation',
   });
 
   await database.storeSubmission({
     key: 'TDL17.101',
     pdf: generateRandomString(1000),
     userId: 'anonymous',
+    userType: 'anonymous',
   });
 
   await database.storeSubmission({
     key: 'TDL17.957',
     pdf: generateRandomString(1000),
     userId: '900026236',
+    userType: 'person',
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6765,7 +6765,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6825,7 +6834,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7387,7 +7403,16 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,9 +11,9 @@
     "@jridgewell/trace-mapping" "^0.3.24"
 
 "@aws-cdk/asset-awscli-v1@^2.2.208":
-  version "2.2.210"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.210.tgz#1bea0c6b4742ab2ed529c2f8344d41ae502a5679"
-  integrity sha512-yxuGP52ZtdAGkcAik5mW79FKKv6yvc5QuCZbsKMyICk48alqs+ni7Iv2UnuGLkVSLh09+ixoHHu4o5rIv8X9jg==
+  version "2.2.211"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.211.tgz#e33c1bab8e45ea3e4100fff1a0f4430a3ba2164d"
+  integrity sha512-56G1FYTiKyec3bEfEI/5UcU0XPnaGUlaDDH7OYClyvqss0HlnmoSulHK2gwai2PGAD1Nk+scPrdfH/MVAkSKuw==
 
 "@aws-cdk/asset-kubectl-v20@^2.1.3":
   version "2.1.3"
@@ -6765,16 +6765,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6834,14 +6825,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7403,16 +7387,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Fixes #
Check migration documentation for full explanation (inline and previous PR's) 
This PR retrieves the newly created entires from dynamodb based on kvk (not kvknummer)
And org | person instad of user