### PR TITLE
fix: branch name main instead of prod. Same config retrieval method a…

### DIFF
--- a/src/app/zgw/rxMissionZgwHandler/RxMissionZgwConfiguration.ts
+++ b/src/app/zgw/rxMissionZgwHandler/RxMissionZgwConfiguration.ts
@@ -257,7 +257,7 @@ const rxMissionConfigurations: { [name: string] : RxMissionZgwConfiguration } = 
     ],
   },
   production: {
-    branchName: 'production',
+    branchName: 'main',
     submissionZaakProperties: [
 
       {


### PR DESCRIPTION
…s main config

Fixes #

RxMissionConfig branch name is main not production.
Same type of config retrieval as repo config, which als has:
![afbeelding](https://github.com/user-attachments/assets/a8ac6333-3430-4b71-b64a-56ec3dd03d6d)


production: {
branchName: 'main' }
Other methods in RxMissionConfig also use branchname to retrieve config